### PR TITLE
1.16+ support

### DIFF
--- a/topomc/common/decode.py
+++ b/topomc/common/decode.py
@@ -10,7 +10,7 @@ def unstream(data, bits_per_value, int_size):
     value = 0
 
     for byte in data:
-        for num in range(int_size):
+        for num in range(int_size): # int_size-1, to support 1.16+
             bit = (byte >> num) & 0x01
             value = (bit << bl) | value
             bl += 1
@@ -18,4 +18,5 @@ def unstream(data, bits_per_value, int_size):
                 result.append(value)
                 value = 0
                 bl = 0
+        # or bl = 0   
     return result

--- a/topomc/common/decode.py
+++ b/topomc/common/decode.py
@@ -1,4 +1,4 @@
-def unstream(data, bits_per_value, int_size):
+def unstream(data, bits_per_value, int_size, legacy=True):
     """
     This function is a pythonic adaptation of Reddit user bxny5's unstream
     function for decoding minecraft chunkheightmap data, written in perl.
@@ -10,7 +10,7 @@ def unstream(data, bits_per_value, int_size):
     value = 0
 
     for byte in data:
-        for num in range(int_size): # int_size-1, to support 1.16+
+        for num in range(int_size):
             bit = (byte >> num) & 0x01
             value = (bit << bl) | value
             bl += 1
@@ -18,5 +18,6 @@ def unstream(data, bits_per_value, int_size):
                 result.append(value)
                 value = 0
                 bl = 0
-        # or bl = 0   
+        if not legacy:
+            bl = 0
     return result

--- a/topomc/parsing/blockmap.py
+++ b/topomc/parsing/blockmap.py
@@ -19,7 +19,7 @@ STREAM_INT_SIZE = 64
 class ChunkTile:
     def __init__(self, chunk_parser, chunk_x, chunk_z):
         
-        def get_chunktag_heightmap(anvil, tag="MOTION_BLOCKING_NO_LEAVES"):
+        def get_chunktag_heightmap(anvil, version_tag, tag="MOTION_BLOCKING_NO_LEAVES"):
             try:
                 tags.index(tag)
             except Exception:
@@ -34,7 +34,7 @@ class ChunkTile:
                 raise Exception(f"Unloaded chunk {chunk_x} {chunk_z}")
 
             chunktag_heightmap = decode.unstream(
-                data_stream, STREAM_BITS_PER_VALUE, STREAM_INT_SIZE
+                data_stream, version_tag, STREAM_BITS_PER_VALUE, STREAM_INT_SIZE
             )
 
             chunktag_heightmap_deepened = []
@@ -49,9 +49,9 @@ class ChunkTile:
 
             return chunktag_heightmap_deepened
 
-        self.anvil_file = chunk_parser.load_at(chunk_x, chunk_z)
+        self.anvil_file, self.version_tag = chunk_parser.load_at(chunk_x, chunk_z)
         self.chunktag_heightmap = get_chunktag_heightmap(
-            self.anvil_file.data, tags[1]
+            self.anvil_file.data, self.version_tag, tags[1]
         )
 
         surface_blocks = app.settings["Surface blocks"]

--- a/topomc/parsing/chunkparser.py
+++ b/topomc/parsing/chunkparser.py
@@ -7,6 +7,7 @@ import anvil
 from topomc import app
 from topomc.common.logger import Logger
 
+DATA_VERSION_INDEX = 1
 
 class ChunkParser:
 
@@ -53,8 +54,9 @@ class ChunkParser:
 
         try:
             chunk = anvil.Chunk.from_region(region, chunkx, chunkz)
+            version_tag = region.chunk_data(chunkx, chunkz)[DATA_VERSION_INDEX]
         except Exception:
             Logger.log(logging.critical, f"Chunk: Chunk {chunkx, chunkz} is not loaded or corrupt")
             sys.exit()
 
-        return chunk
+        return chunk, version_tag


### PR DESCRIPTION
Either of the comments will be able to support maps above 1.16, choose one or the other. 

fixed : bl was set to one starting at the next iteration when it needed to be zero (i.e off by one) .